### PR TITLE
change class-variance-authority version to 0.7.0

### DIFF
--- a/packages/cli/src/commands/common/dependencies.ts
+++ b/packages/cli/src/commands/common/dependencies.ts
@@ -20,7 +20,7 @@ export const dependencies = {
 
   // ShadCN/ui
   "@radix-ui/react-slot": "^1.0.2",
-  "class-variance-authority": "^0.8.0",
+  "class-variance-authority": "^0.7.0",
   clsx: "^2.1.0",
   "lucide-react": "^0.316.0",
   "tailwind-merge": "^2.2.1",


### PR DESCRIPTION
I was having a problem using the cli together with auto npm install, I believe this should solve it

<img width="1118" alt="image" src="https://github.com/miljan-code/next-kickstart/assets/21091242/583c2456-2f8c-42a5-99ae-4d1ea9740d13">

if we list the package versions with
```shell
npm view class-variance-authority
```
It is possible to see that the canary is` 0.7.1-canary.2` and latest `0.7.0.`
